### PR TITLE
Format by goimports

### DIFF
--- a/templates/commands.tmpl
+++ b/templates/commands.tmpl
@@ -1,9 +1,10 @@
 package main
 
 import (
-    "os"
-	"github.com/codegangsta/cli"
 	"log"
+	"os"
+
+	"github.com/codegangsta/cli"
 )
 
 var Commands = []cli.Command{

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/codegangsta/cli"
 	"os"
+
+	"github.com/codegangsta/cli"
 )
 
 func main() {


### PR DESCRIPTION
I'm using "[goimports](https://github.com/bradfitz/goimports)" for format of `import` statement instead of "gofmt".

I think "goimports" is better than "gofmt".
So, I've updated templates.
