### PR TITLE
Use flag var

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,6 +7,7 @@ This is road map of `gcli`, what I'm doing for next release and planing for futu
 - `godoc`
 - More document for flag
 - Global option for command pattern
+- **Done**: Usge `flag.Var`
 - **Done**: Generate bash script
 - **Done**: More verbose outputs in `skeleton` package
 - **Done** `go vet` tests for artifacts

--- a/command/flag_flag_test.go
+++ b/command/flag_flag_test.go
@@ -30,7 +30,7 @@ func TestFlagFlag_Set(t *testing.T) {
 					Name:        "debug",
 					LongName:    "debug",
 					ShortName:   "d",
-					TypeString:  "String",
+					TypeString:  skeleton.TypeStringString,
 					Default:     "\"\"",
 					Description: "Run as debug mode",
 				},
@@ -40,9 +40,9 @@ func TestFlagFlag_Set(t *testing.T) {
 			arg:     `debug,help,test`,
 			success: true,
 			expect: []skeleton.Flag{
-				{Name: "debug", LongName: "debug", ShortName: "d", TypeString: "String", Default: "\"\""},
-				{Name: "help", LongName: "help", ShortName: "h", TypeString: "String", Default: "\"\""},
-				{Name: "test", LongName: "test", ShortName: "t", TypeString: "String", Default: "\"\""},
+				{Name: "debug", LongName: "debug", ShortName: "d", TypeString: skeleton.TypeStringString, Default: "\"\""},
+				{Name: "help", LongName: "help", ShortName: "h", TypeString: skeleton.TypeStringString, Default: "\"\""},
+				{Name: "test", LongName: "test", ShortName: "t", TypeString: skeleton.TypeStringString, Default: "\"\""},
 			},
 		},
 	}

--- a/command/new.go
+++ b/command/new.go
@@ -165,7 +165,7 @@ func (c *NewCommand) Run(args []string) int {
 			}
 			return ExitCodeFailed
 		case <-doneCh:
-			c.UI.Info(fmt.Sprintf("====> Successfuly generated %s", name))
+			c.UI.Info(fmt.Sprintf("====> Successfully generated %s", name))
 			return ExitCodeOK
 		}
 	}

--- a/skeleton/flag.go
+++ b/skeleton/flag.go
@@ -5,6 +5,13 @@ import (
 	"strings"
 )
 
+// TypeString represents type as string
+const (
+	TypeStringInt    = "int"
+	TypeStringBool   = "bool"
+	TypeStringString = "string"
+)
+
 // Flag stores flag meta informations
 type Flag struct {
 	// Name is flag name, this is used for flag variable name in generated code.
@@ -55,13 +62,13 @@ func (f *Flag) Fix() error {
 func (f *Flag) fixTypeString() error {
 	switch strings.ToLower(f.TypeString) {
 	case "bool", "b":
-		f.TypeString = "Bool"
+		f.TypeString = TypeStringBool
 		f.Default = false
 	case "int", "i":
-		f.TypeString = "Int"
+		f.TypeString = TypeStringInt
 		f.Default = 0
 	case "string", "str", "s":
-		f.TypeString = "String"
+		f.TypeString = TypeStringString
 		f.Default = "\"\""
 	default:
 		return fmt.Errorf("unexpected type is provided: %s", f.TypeString)

--- a/skeleton/flag_test.go
+++ b/skeleton/flag_test.go
@@ -18,7 +18,7 @@ func TestFix(t *testing.T) {
 				Name:        "debug",
 				ShortName:   "d",
 				LongName:    "debug",
-				TypeString:  "Bool",
+				TypeString:  TypeStringBool,
 				Default:     false,
 				Description: "Run as DEBUG mode",
 			},
@@ -35,7 +35,7 @@ func TestFix(t *testing.T) {
 				Name:        "token",
 				ShortName:   "t",
 				LongName:    "token",
-				TypeString:  "String",
+				TypeString:  TypeStringString,
 				Default:     "\"\"",
 				Description: "",
 			},
@@ -75,63 +75,63 @@ func TestFixTypeString(t *testing.T) {
 		{
 			in:            &Flag{TypeString: "int"},
 			success:       true,
-			expTypeString: "Int",
+			expTypeString: TypeStringInt,
 			expDefault:    0,
 		},
 
 		{
 			in:            &Flag{TypeString: "Int"},
 			success:       true,
-			expTypeString: "Int",
+			expTypeString: TypeStringInt,
 			expDefault:    0,
 		},
 
 		{
 			in:            &Flag{TypeString: "i"},
 			success:       true,
-			expTypeString: "Int",
+			expTypeString: TypeStringInt,
 			expDefault:    0,
 		},
 
 		{
 			in:            &Flag{TypeString: "string"},
 			success:       true,
-			expTypeString: "String",
+			expTypeString: TypeStringString,
 			expDefault:    "\"\"",
 		},
 
 		{
 			in:            &Flag{TypeString: "s"},
 			success:       true,
-			expTypeString: "String",
+			expTypeString: TypeStringString,
 			expDefault:    "\"\"",
 		},
 
 		{
 			in:            &Flag{TypeString: "str"},
 			success:       true,
-			expTypeString: "String",
+			expTypeString: TypeStringString,
 			expDefault:    "\"\"",
 		},
 
 		{
 			in:            &Flag{TypeString: "bool"},
 			success:       true,
-			expTypeString: "Bool",
+			expTypeString: TypeStringBool,
 			expDefault:    false,
 		},
 
 		{
 			in:            &Flag{TypeString: "b"},
 			success:       true,
-			expTypeString: "Bool",
+			expTypeString: TypeStringBool,
 			expDefault:    false,
 		},
 
 		{
 			in:            &Flag{TypeString: "enexpected_type"},
 			success:       false,
-			expTypeString: "Bool",
+			expTypeString: TypeStringBool,
 			expDefault:    false,
 		},
 	}

--- a/skeleton/resource/tmpl/flag/cli.go.tmpl
+++ b/skeleton/resource/tmpl/flag/cli.go.tmpl
@@ -21,14 +21,17 @@ type CLI struct {
 
 // Run invokes the CLI with the given arguments.
 func (cli *CLI) Run(args []string) int {
-
+    var (
+		{{ range .Flags }}{{ .Name }} {{ .TypeString }}
+        {{ end }}
+    )
+    
 	// Define option flag parse
 	flags := flag.NewFlagSet(Name, flag.ContinueOnError)
     flags.SetOutput(cli.errStream)
 
-    {{ range .Flags }}
-	fl{{ title .Name }} := flags.{{.TypeString}}("{{.LongName}}", {{ .Default }}, "{{ .Description }}")
-	{{ end }}
+    {{ range .Flags }}flags.{{ title .TypeString}}Var(&{{ .Name }}, "{{ .LongName }}", {{ .Default }}, "")
+    {{ end }}
 	flVersion := flags.Bool("version", false, "Print version information and quit.")
 
 	// Parse commandline flag
@@ -43,7 +46,7 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	{{ range .Flags }}
-	_ = fl{{ title .Name }}
+	_ = {{ .Name }}
 	{{ end }}
 
 	return ExitCodeOK

--- a/skeleton/resource/tmpl/flag/cli.go.tmpl
+++ b/skeleton/resource/tmpl/flag/cli.go.tmpl
@@ -30,7 +30,7 @@ func (cli *CLI) Run(args []string) int {
 	flags := flag.NewFlagSet(Name, flag.ContinueOnError)
     flags.SetOutput(cli.errStream)
 
-    {{ range .Flags }}flags.{{ title .TypeString}}Var(&{{ .Name }}, "{{ .LongName }}", {{ .Default }}, "")
+    {{ range .Flags }}flags.{{ title .TypeString}}Var(&{{ .Name }}, "{{ .LongName }}", {{ .Default }}, "{{ .Description }}")
     {{ end }}
 	flVersion := flags.Bool("version", false, "Print version information and quit.")
 

--- a/tests/command_framework_test.go
+++ b/tests/command_framework_test.go
@@ -56,7 +56,7 @@ func TestNew_command_frameworks(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expect := "Successfuly generated"
+		expect := "Successfully generated"
 		if !strings.Contains(output, expect) {
 			t.Fatalf("[%s] expect %q to contain %q", tt.framework, output, expect)
 		}

--- a/tests/flag_framework_test.go
+++ b/tests/flag_framework_test.go
@@ -47,7 +47,7 @@ func TestNew_flag_frameworks(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expect := "Successfuly generated"
+		expect := "Successfully generated"
 		if !strings.Contains(output, expect) {
 			t.Fatalf("[%s] expect %q to contain %q", tt.framework, output, expect)
 		}


### PR DESCRIPTION
Use `flag.Var` (This is just my preference),

```bash
$ make build && ./bin/gcli new -F flag -f file:string -f worker:int -f debug:bool test
```

This will generate, 

```go
var (
         file   string
         worker int
         debug  bool
)

flags.StringVar(&file, "file", "", "")
flags.IntVar(&worker, "worker", 0, "")
flags.BoolVar(&debug, "debug", false, "")
```