### PR TITLE
Enable to run gcli from anywhere

### DIFF
--- a/command/new_test.go
+++ b/command/new_test.go
@@ -33,7 +33,7 @@ func TestNewCommand(t *testing.T) {
 	}
 	defer backFunc()
 
-	args := []string{"-F", "mitchellh_cli", "-owner", "deeeet", "todo"}
+	args := []string{"-F", "mitchellh_cli", "-current", "-owner", "gopher-gcli", "todo"}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad status code: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
@@ -67,7 +67,7 @@ func TestNewCommand_directoryExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	args := []string{"todo"}
+	args := []string{"-current", "-owner", "gopher-gcli", "todo"}
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad status code: %d", code)
 	}

--- a/tests/design_flow_test.go
+++ b/tests/design_flow_test.go
@@ -62,6 +62,7 @@ func TestDesignFlow(t *testing.T) {
 	// Apply to genearte cli project
 	applyArgs := []string{
 		"apply",
+		"-current",
 		designFile,
 	}
 


### PR DESCRIPTION
Until today, you need to run `gcli` on `$GOPATH/src/github.com/<owner>`. Now it enable you to run it  anywhere (But shows warnings). 

```bash
$ pwd
/tmp
```
```bash
$gcli new todo 

====> WARNING: You are not in the directory gcli expects.
      The codes will be generated be in $GOPATH/src/github.com/tcnksm.
      Not in the current directory. This is because the output
      codes use import path based on that path.

  Created /Users/taichi.nakashima/src/github.com/tcnksm/todo/.gitignore
  Created /Users/taichi.nakashima/src/github.com/tcnksm/todo/CHANGELOG.md
  Created /Users/taichi.nakashima/src/github.com/tcnksm/todo/version.go
  Created /Users/taichi.nakashima/src/github.com/tcnksm/todo/commands.go
  Created /Users/taichi.nakashima/src/github.com/tcnksm/todo/README.md
  Created /Users/taichi.nakashima/src/github.com/tcnksm/todo/main.go
====> Successfully generated todo
```