### PR TITLE
Change VCS

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -23,6 +23,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		owner        string
 		name         string
 		staticDir    string
+		vcsHost      string
 		current      bool
 		skipTest     bool
 		verbose      bool
@@ -34,6 +35,8 @@ func (c *ApplyCommand) Run(args []string) int {
 	uflag.StringVar(&frameworkStr, "F", "", "framework (short)")
 
 	uflag.StringVar(&staticDir, "static-dir", "", "")
+
+	uflag.StringVar(&vcsHost, "vcs", DefaultVCSHost, "")
 
 	uflag.BoolVar(&current, "current", false, "current")
 	uflag.BoolVar(&current, "C", false, "current")
@@ -107,13 +110,13 @@ func (c *ApplyCommand) Run(args []string) int {
 			"Failed to read GOPATH: it should not be empty"))
 		return ExitCodeFailed
 	}
-	idealDir := filepath.Join(gopath, "src", "github.com", owner)
+	idealDir := filepath.Join(gopath, "src", vcsHost, owner)
 
 	output := executable.Name
 	if currentDir != idealDir && !current {
 		c.UI.Output("")
 		c.UI.Output(fmt.Sprintf("====> WARNING: You are not in the directory gcli expects."))
-		c.UI.Output(fmt.Sprintf("      The codes will be generated be in $GOPATH/src/github.com/%s.", owner))
+		c.UI.Output(fmt.Sprintf("      The codes will be generated be in $GOPATH/src/%s/%s.", vcsHost, owner))
 		c.UI.Output(fmt.Sprintf("      Not in the current directory. This is because the output"))
 		c.UI.Output(fmt.Sprintf("      codes use import path based on that path."))
 		c.UI.Output("")
@@ -136,7 +139,9 @@ func (c *ApplyCommand) Run(args []string) int {
 		}
 	}
 
-	fmt.Println(frameworkStr)
+	// Set VCSHost
+	executable.VCSHost = vcsHost
+
 	framework, err := skeleton.FrameworkByName(frameworkStr)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Failed to generate %q: %s", executable.Name, err.Error()))
@@ -226,6 +231,8 @@ Options:
    -framework=name, -F        Cli framework name. By default, gcli use "codegangsta/cli"
                               To check cli framework you can use, run 'gcli list'.
                               If you set invalid framework, it will be failed.
+
+   -vcs=name                  Version Control Host name. By default, gcli use 'github.com'.
 
    -skip-test, -T             Skip generating *_test.go file. By default, gcli generates
                               test file If you specify this flag, gcli will not generate

--- a/command/meta.go
+++ b/command/meta.go
@@ -21,6 +21,9 @@ const (
 )
 
 const (
+	// DefaultVCSHost is the default VCS host name.
+	DefaultVCSHost = "github.com"
+
 	// DefaultLocalDir is the default path to store directory.
 	DefaultLocalDir       = "~/.gcli.d"
 	DefaultLocalStaticDir = "static"

--- a/command/new.go
+++ b/command/new.go
@@ -24,6 +24,7 @@ func (c *NewCommand) Run(args []string) int {
 		frameworkStr string
 		owner        string
 		staticDir    string
+		vcsHost      string
 		current      bool
 		skipTest     bool
 		verbose      bool
@@ -44,6 +45,8 @@ func (c *NewCommand) Run(args []string) int {
 	uflag.StringVar(&owner, "o", "", "owner (short)")
 
 	uflag.StringVar(&staticDir, "static-dir", "", "")
+
+	uflag.StringVar(&vcsHost, "vcs", DefaultVCSHost, "")
 
 	uflag.BoolVar(&current, "current", false, "current")
 	uflag.BoolVar(&current, "C", false, "current")
@@ -96,13 +99,13 @@ func (c *NewCommand) Run(args []string) int {
 			"Failed to read GOPATH: it should not be empty"))
 		return ExitCodeFailed
 	}
-	idealDir := filepath.Join(gopath, "src", "github.com", owner)
+	idealDir := filepath.Join(gopath, "src", vcsHost, owner)
 
 	output := name
 	if currentDir != idealDir && !current {
 		c.UI.Output("")
 		c.UI.Output(fmt.Sprintf("====> WARNING: You are not in the directory gcli expects."))
-		c.UI.Output(fmt.Sprintf("      The codes will be generated be in $GOPATH/src/github.com/%s.", owner))
+		c.UI.Output(fmt.Sprintf("      The codes will be generated be in $GOPATH/src/%s/%s.", vcsHost, owner))
 		c.UI.Output(fmt.Sprintf("      Not in the current directory. This is because the output"))
 		c.UI.Output(fmt.Sprintf("      codes use import path based on that path."))
 		c.UI.Output("")
@@ -134,6 +137,7 @@ func (c *NewCommand) Run(args []string) int {
 	executable := &skeleton.Executable{
 		Name:        name,
 		Owner:       owner,
+		VCSHost:     vcsHost,
 		Commands:    commands,
 		Flags:       flags,
 		Version:     skeleton.DefaultVersion,
@@ -225,6 +229,8 @@ Options:
    -owner=name, -o            Command owner (author) name. This value is also used for
                               import path name. By default, owner name is extracted from
                               ~/.gitconfig variable.
+
+   -vcs=name                  Version Control Host name. By default, gcli use 'github.com'.
 
    -skip-test, -T             Skip generating *_test.go file. By default, gcli generates
                               test file If you specify this flag, gcli will not generate

--- a/skeleton/executable.go
+++ b/skeleton/executable.go
@@ -21,6 +21,9 @@ type Executable struct {
 	// Owner is owner of the executable.
 	Owner string
 
+	// VSCHost is the host name of version control system.
+	VCSHost string `toml:",omitempty"`
+
 	// Commands are commands of the executable.
 	Commands []*Command
 

--- a/skeleton/main.go
+++ b/skeleton/main.go
@@ -14,11 +14,11 @@ type Skeleton struct {
 	// Path is where skeleton is generated.
 	Path string
 
-	// If WithTest is true, also generate test code.
-	SkipTest bool
-
 	Framework  *Framework
 	Executable *Executable
+
+	// If WithTest is true, also generate test code.
+	SkipTest bool
 
 	// ArtifactCh is channel for info output
 	ArtifactCh chan string

--- a/skeleton/resource/tmpl/codegangsta_cli/commands.go.tmpl
+++ b/skeleton/resource/tmpl/codegangsta_cli/commands.go.tmpl
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/{{ .Owner }}/{{ .Name }}/command"
+	"{{ .VCSHost }}/{{ .Owner }}/{{ .Name }}/command"
 )
 
 var GlobalFlags = []cli.Flag{

--- a/skeleton/resource/tmpl/mitchellh_cli/cli.go.tmpl
+++ b/skeleton/resource/tmpl/mitchellh_cli/cli.go.tmpl
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/mitchellh/cli"
-	"github.com/{{.Owner}}/{{.Name}}/command"
+	"{{ .VCSHost }}/{{.Owner}}/{{.Name}}/command"
 )
 
 func Run(args []string) int {

--- a/skeleton/resource/tmpl/mitchellh_cli/commands.go.tmpl
+++ b/skeleton/resource/tmpl/mitchellh_cli/commands.go.tmpl
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/mitchellh/cli"
-	"github.com/{{ .Owner }}/{{ .Name }}/command"
+	"{{ .VCSHost }}/{{ .Owner }}/{{ .Name }}/command"
 )
 
 func Commands(meta *command.Meta) map[string]cli.CommandFactory {

--- a/tests/apply_test.go
+++ b/tests/apply_test.go
@@ -110,3 +110,52 @@ func TestApply_gotests(t *testing.T) {
 		}
 	}
 }
+
+func TestApply_vcs(t *testing.T) {
+	t.Parallel()
+
+	vcsHost := "bitbucket.org"
+	owner := "awesome_user_" + strconv.Itoa(int(time.Now().Unix()))
+
+	gopath, cleanFunc, err := tmpGopath()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer cleanFunc()
+
+	baseDir := filepath.Join(gopath, "src", vcsHost, owner)
+	if err := os.MkdirAll(baseDir, 0777); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	designFile, err := filepath.Abs(testDesignFile)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	for _, tt := range applyTests {
+		name := fmt.Sprintf("%s_todo_design_file", tt.framework)
+		args := []string{
+			"apply",
+			"-framework", tt.framework,
+			"-owner", owner,
+			"-vcs", vcsHost,
+			"-name", name,
+			designFile,
+		}
+
+		output, err := runGcli(baseDir, gopath, args)
+		if err != nil {
+			t.Fatalf("[%s] expects %s to be nil", tt.framework, err)
+		}
+
+		expectWarn := "WARNING: You are not in the directory gcli expects."
+		if strings.Contains(output, expectWarn) {
+			t.Fatalf("expects output not to contain %q", expectWarn)
+		}
+
+		if err := goTests(filepath.Join(baseDir, name), gopath); err != nil {
+			t.Fatalf("[%s] expects generated project to pass all go tests: \n\n %s", tt.framework, err)
+		}
+	}
+}


### PR DESCRIPTION
Version Control Host name can be configured by command line option. For example, to use [bitbucket.org](bitbucket.org), 

```bash
$ gcli new -F mitchellh_cli -vcs gcli new -F mitchellh_cli -vcs bitbucket.org -c add -c delete -c list todo 

====> WARNING: You are not in the directory gcli expects.
      The codes will be generated be in $GOPATH/src/bitbucket.org/tcnksm.
      Not in the current directory. This is because the output
      codes use import path based on that path.

  Created /Users/taichi.nakashima/src/bitbucket.org/tctodo/Makefile
  Created /Users/taichi.nakashima/src/bitbucket.org/tcnksm/todo/README.md
  Created /Users/taichi.nakashima/src/bitbucket.org/tcnksm/todo/.gitignore
  Created /Users/taichi.nakashima/src/bitbucket.org/tcnksm/todo/command/meta.go
  Created /Users/taichi.nakashima/src/bitbucket.org/tcnksm/todo/version.go
....
```

This PR is related to https://github.com/tcnksm/gcli/issues/48
