### PR TITLE
Fix -v, -version, and --version options

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -36,10 +36,7 @@ func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
 		// If the following options are provided,
 		// then execute gcli version command
 		if arg == "-v" || arg == "-version" || arg == "--version" {
-			newArgs := make([]string, len(args)+1)
-			newArgs[0] = "version"
-			copy(newArgs[1:], args)
-			args = newArgs
+			args[1] = "version"
 			break
 		}
 

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	t.Parallel()
+
+	args := []string{
+		"--version",
+	}
+
+	gopath, cleanFunc, err := tmpGopath()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer cleanFunc()
+
+	output, err := runGcli("./", gopath, args)
+	if err != nil {
+		t.Fatalf("expects %s to be nil", err)
+	}
+
+	// expect sample: gcli version v0.2.3
+	expect := regexp.MustCompile(`gcli version v\d+\.\d+\.\d+`)
+	if !expect.MatchString(output) {
+		t.Fatalf("expects output not to contain %q %s", expect, output)
+	}
+}


### PR DESCRIPTION
because `gcli -v` ( `-version`, `--version` also) doesn't work :wrench:

before:

```console
$ gcli --version
usage: gcli [--version] [--help] <command> [<args>]

Available commands are:
    apply       Apply design template file for generating cli project
    design      Generate project design template
    list        List available cli frameworks
    new         Generate new cli project
    validate    Validate design template file
    version     Print the gcli version
```

after:

```console
$ gcli --version
gcli version v0.2.3 ("dedeb02")
```