### PR TITLE
add urfave/cli framework template

### DIFF
--- a/skeleton/framework.go
+++ b/skeleton/framework.go
@@ -76,6 +76,24 @@ The goal is to enable developers to write fast and distributable command line ap
 	},
 
 	{
+		Name:     "urfave_cli",
+		AltNames: []string{"urfave"},
+		URL:      "https://github.com/urfave/cli",
+		Description: `This is the library formally known as codegangsta/cli. urfave/cli is simple, fast, and fun package for building command line apps in Go.
+The goal is to enable developers to write fast and distributable command line applications in an expressive way.
+`,
+		BaseTemplates: []Template{
+			{"resource/tmpl/urfave_cli/main.go.tmpl", "main.go"},
+			{"resource/tmpl/urfave_cli/version.go.tmpl", "version.go"},
+			{"resource/tmpl/urfave_cli/commands.go.tmpl", "commands.go"},
+		},
+		CommandTemplates: []Template{
+			{"resource/tmpl/urfave_cli/command/command.go.tmpl", "command/{{ .Name }}.go"},
+			{"resource/tmpl/urfave_cli/command/command_test.go.tmpl", "command/{{ .Name }}_test.go"},
+		},
+	},
+
+	{
 		Name: "go_cmd",
 		URL:  "https://github.com/golang/go/tree/master/src/cmd/go",
 		Description: `

--- a/skeleton/resource/tmpl/urfave_cli/command/command.go.tmpl
+++ b/skeleton/resource/tmpl/urfave_cli/command/command.go.tmpl
@@ -1,0 +1,9 @@
+package command
+
+import "github.com/urfave/cli"
+
+func Cmd{{ title .FunctionName }}(c *cli.Context) error {
+	// Write your code here
+    {{ if ne .DebugOutput "" }}print("{{ .DebugOutput }}"){{ end }}
+		return nil
+}

--- a/skeleton/resource/tmpl/urfave_cli/command/command_test.go.tmpl
+++ b/skeleton/resource/tmpl/urfave_cli/command/command_test.go.tmpl
@@ -1,0 +1,7 @@
+package command
+
+import "testing"
+
+func TestCmd{{ title .FunctionName }}(t *testing.T) {
+	// Write your code here
+}

--- a/skeleton/resource/tmpl/urfave_cli/commands.go.tmpl
+++ b/skeleton/resource/tmpl/urfave_cli/commands.go.tmpl
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+	"{{ .VCSHost }}/{{ .Owner }}/{{ .Name }}/command"
+)
+
+var GlobalFlags = []cli.Flag{
+    {{ range .Flags }}cli.{{ title .TypeString }}Flag{
+	    EnvVar: "ENV_{{ toUpper .Name }}",
+	    Name:   "{{ .LongName }}",
+	    {{ if eq .TypeString "string" }}Value: "{{ .Default }}", {{ end }}
+	    Usage:  "{{ .Description }}",
+    },
+    {{ end }}
+}
+
+var Commands = []cli.Command{
+    {{ range .Commands }}{
+		Name:        "{{ .Name }}",
+		Usage:       "{{ .Synopsis }}",
+		Action:      command.Cmd{{ title .FunctionName }},
+		Flags:       []cli.Flag{},
+	},
+    {{ end }}
+}
+
+func CommandNotFound(c *cli.Context, command string) {
+	fmt.Fprintf(os.Stderr, "%s: '%s' is not a %s command. See '%s --help'.", c.App.Name, command, c.App.Name, c.App.Name)
+	os.Exit(2)
+}

--- a/skeleton/resource/tmpl/urfave_cli/main.go.tmpl
+++ b/skeleton/resource/tmpl/urfave_cli/main.go.tmpl
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"github.com/urfave/cli"
+)
+
+func main() {
+
+	app := cli.NewApp()
+	app.Name = Name
+	app.Version = Version
+	app.Author = "{{ .Owner }}"
+	app.Email = ""
+	app.Usage = "{{ .Description }}"
+
+	app.Flags = GlobalFlags
+	app.Commands = Commands
+	app.CommandNotFound = CommandNotFound
+
+	app.Run(os.Args)
+}

--- a/skeleton/resource/tmpl/urfave_cli/version.go.tmpl
+++ b/skeleton/resource/tmpl/urfave_cli/version.go.tmpl
@@ -1,0 +1,4 @@
+package main
+
+const Name string = "{{ .Name }}"
+const Version string = "{{ .Version }}"


### PR DESCRIPTION
Hi @tcnksm 
`codegangsta/cli` has been migrated to `urfave/cli`. So I added `urfave/cli` framework template, because `ActionFunc` was changed. `ActionFunc` returns an error.

Thank you.