### PR TITLE
Fix typos

### DIFF
--- a/command/new.go
+++ b/command/new.go
@@ -266,7 +266,7 @@ Examples:
 
 To create todo command application skeleton which has 'add' and 'delete' command,
 
-   $ gcli new -command=add:"Add new task" -commnad=delete:"delete task" todo
+   $ gcli new -command=add:"Add new task" -command=delete:"delete task" todo
 `
 	return strings.TrimSpace(helpText)
 }

--- a/doc.go
+++ b/doc.go
@@ -144,7 +144,7 @@ Examples:
 
 To create todo command application skeleton which has 'add' and 'delete' command,
 
-   $ gcli new -command=add:"Add new task" -commnad=delete:"delete task" todo
+   $ gcli new -command=add:"Add new task" -command=delete:"delete task" todo
 
 
 


### PR DESCRIPTION
I found typos in help text and fixes: `commnad` -> `command`