### PR TITLE
Makefile: go 1.6 has vet included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ deps:
 
 devdeps:
 	@echo "====> Install depedencies for development..."
-	go get -v golang.org/x/tools/cmd/vet	
 	go get -v github.com/golang/lint/golint
 
 generate: deps


### PR DESCRIPTION
Since go 1.6 has vet included, `make install` fails when attempting `go get -v golang.org/x/tools/cmd/vet`

Seems like it'd be wise to remove it from the `Makefile`