### PR TITLE
Not to fetch dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ install:
   - echo "skipping travis' default"
 
 script:
+  - make bootstrap
   - make test  

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
-COMMIT = $$(git describe --always)
-DEBUG_FLAG = $(if $(DEBUG),-debug)
+VERSION = $(shell grep 'Version string' version.go | sed -E 's/.*"(.+)"$$/\1/')
+COMMIT = $(shell git describe --always)
+PACKAGES = $(shell go list ./... | grep -v '/vendor/')
+EXTERNAL_TOOLS = github.com/jteeuwen/go-bindata
 
-updatedeps:
+default: test
+
+# install external tools for this project
+bootstrap:
 	@echo "====> Install & Update depedencies..."
-	go get -v -u github.com/jteeuwen/go-bindata/...
-	go get -v -d -u -t ./...
-
-deps:
-	@echo "====> Install depedencies..."
-	go get -v github.com/jteeuwen/go-bindata/...
-	go get -v -d -t ./...
-
-devdeps:
-	@echo "====> Install depedencies for development..."
-	go get -v github.com/golang/lint/golint
+	@for tool in $(EXTERNAL_TOOLS) ; do \
+		echo "Installing $$tool" ; \
+    	go get $$tool; \
+	done
 
 generate: 
 	@go generate ./...
+
+godoc: build
+	@echo "====> Generate doc.go"
+	@rm doc.go
+	@./bin/gcli -godoc
 
 build: generate
 	@echo "====> Build gcli in ./bin "
@@ -26,19 +29,36 @@ install: generate
 	@echo "====> Install gcli in $(GOPATH)/bin ..."
 	@go install -ldflags "-X main.GitCommit=\"$(COMMIT)\""
 
-test: build devdeps
-	@echo "====> Run test"
-	@sh -c "$(CURDIR)/test.sh"
+.PHONY: bootstrap generate godoc build install
 
-test-race: generate devdeps
-	go test -race ./...
+test-all: vet lint test test-race
+
+test: build
+	go test -v -parallel=4 ${PACKAGES}
+
+test-race:
+	go test -v -race ${PACKAGES}
 
 # Run functional test 
 test-functional: build devdeps
 	@echo "====> Run functional test"
 	cd tests; go test -v ./...
 
-godoc: build
-	@echo "====> Generate doc.go"
-	@rm doc.go
-	@./bin/gcli -godoc
+vet:
+	go vet ${PACKAGES}
+
+lint:
+	@go get github.com/golang/lint/golint
+	go list ./... | grep -v vendor | xargs -n1 golint |\
+		grep -v godoc.go |\
+		grep -v bindata.go |\		
+
+cover:
+	@go get golang.org/x/tools/cmd/cover		
+	go test -coverprofile=cover.out
+	go tool cover -html cover.out
+	rm cover.out
+
+.PHONY: test test-race test-functional test-all vet lint cover  
+
+


### PR DESCRIPTION
Current `makefile` tries to fetch dependency when test. Now we have all dependencies in `vendor` directory, so we can skip it.