### PR TITLE
Revert "Skip deps when build/intall"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ devdeps:
 	@echo "====> Install depedencies for development..."
 	go get -v github.com/golang/lint/golint
 
-generate: 
+generate: deps
 	@go generate ./...
 
 build: generate


### PR DESCRIPTION
Thanks for the cool tool. very helpful :smile:  

When do `make install`, it required go-bindata.  
So, I reverted the commit.  